### PR TITLE
feat: change NCS ID display to 連盟ID on player detail page

### DIFF
--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -30,7 +30,7 @@
     <h1 class="pt-3"><%= @player.name_en + ' ( ' + @player.name_jp + ' )' %></h1>
     <hr>
 
-    <h5 class="">NCS ID: <%= @player.ncs_id %></h4>
+    <h5 class="">連盟ID: <%= @player.ncs_id %></h4>
     <h4 class="">Rating: <%= @player.current_rating %>, Best: <%= @player.best_rating %></h4>
     <h4 class="">Rank: <%= @player.current_rank %>, Best: <%= @player.best_rank %></h4>
 


### PR DESCRIPTION
This PR changes the display of "NCS ID" to "連盟ID" on the player detail page.

## Changes
- Updated `app/views/players/show.html.erb` to show "連盟ID" instead of "NCS ID"

Closes #37

Generated with [Claude Code](https://claude.ai/code)