### PR TITLE
Add rating change ranking

### DIFF
--- a/app/controllers/rating_changes_controller.rb
+++ b/app/controllers/rating_changes_controller.rb
@@ -1,0 +1,26 @@
+class RatingChangesController < ApplicationController
+  def index
+    @search_parameter = search_params
+    current_month = @search_parameter.month
+    last_month = current_month.last_month
+    current_records = Record.year_is(current_month.year).month_is(current_month.month)
+    last_records = Record.year_is(last_month.year).month_is(last_month.month)
+    last_records_map = last_records.index_by(&:player_id)
+
+    @changes = []
+    current_records.each do |record|
+      prev = last_records_map[record.player_id]
+      next unless prev
+
+      diff = record.standard_rating - prev.standard_rating
+      @changes << { record: record, diff: diff }
+    end
+    @changes.sort_by! { |c| -c[:diff] }
+  end
+
+  private
+
+  def search_params
+    PlayerSearchParameter.new(params.fetch(:player_search_parameter, {}))
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,6 +13,12 @@
           <% end %>
         </li>
         <li class="nav-item">
+          <%= link_to rating_changes_path, {class: "nav-link"} do %>
+            <i class="fa-solid fa-arrow-trend-up"></i>
+            <%= t('views.header.ratingChange') %>
+          <% end %>
+        </li>
+        <li class="nav-item">
           <%= link_to distribution_path, {class: "nav-link"} do %>
             <i class="fa-solid fa-chart-simple"></i>
             <%= t('views.header.distribution') %>

--- a/app/views/rating_changes/index.html.erb
+++ b/app/views/rating_changes/index.html.erb
@@ -1,0 +1,58 @@
+<% content_for :title do %>
+  <title><%= t('views.ratingChanges.title') %></title>
+<% end %>
+<% content_for :description do %>
+  <meta name="description" content="<%= t('views.ratingChanges.description') %>">
+<% end %>
+
+<div class="container" style="min-height: 100%;">
+  <div class="row mx-auto pl-1 pr-1 min-vh-100">
+    <div class="d-flex flex-column mx-auto mw-100">
+      <div>
+        <%= render "layouts/header" %>
+        <h1>
+          <%= link_to rating_changes_path, {class: 'nav-link text-body ps-0'} do %>
+            <i class="fa-solid fa-arrow-trend-up d-none d-md-inline"></i>
+            <%= t('views.ratingChanges.title') %>
+          <% end %>
+        </h1>
+        <div>
+          <%= t('views.ratingChanges.description') %>
+        </div>
+        <hr>
+      </div>
+
+      <div class="table-responsive mt-3">
+        <%= form_with model: @search_parameter, url: rating_changes_path, method: :get, local: true, skip_enforcing_utf8: true, html: {class: 'collapse2', id: 'collapseExample2'} do |form| %>
+          <%= hidden_field_tag 'locale', I18n.locale %>
+          <div class="mb-3 align-middle">
+            <%= form.label :month, class: 'align-middle' %>
+            <%= form.select :month, Record.month_array, {selected: @search_parameter.selected_month}, {class: 'align-middle'} %>
+            <%= form.submit 'Update', name: nil, class: 'btn btn-outline-primary ms-1 btn-sm' %>
+          </div>
+        <% end %>
+
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Rank</th>
+              <th>Name</th>
+              <th>Rating Change</th>
+              <th>Current Rating</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @changes.each_with_index do |change, index| %>
+              <tr>
+                <td><%= index + 1 %></td>
+                <td><%= link_to change[:record].player.name_en, change[:record].player %></td>
+                <td><%= change[:diff] %></td>
+                <td><%= change[:record].standard_rating %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
       distribution: "Distribution"
       victoryDistance: "Victory Distance"
       comparePlayers: "Compare Players"
+      ratingChange: "Rating Change"
     pagination:
       first: "&laquo"
       last: "&raquo"
@@ -58,6 +59,9 @@ en:
       tooManyPlayers: "Maximum %{count} players can be displayed"
       ratingRange: "Rating range to display on the graph"
       graphInfo: "If the graph is distorted, please view it on a larger screen such as a computer."
+    ratingChanges:
+      title: "Rating Change Ranking"
+      description: "Ranking of players by monthly rating increase"
   activerecord:
     errors:
       models:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
       distribution: "分布"
       victoryDistance: "到達勝利距離"
       comparePlayers: "プレーヤー比較"
+      ratingChange: "レーティング変動"
     pagination:
       first: "&laquo"
       last: "&raquo"
@@ -57,6 +58,9 @@ ja:
       tooManyPlayers: "最大%{count}人まで表示できます"
       ratingRange: "グラフに表示するレーティング範囲"
       graphInfo: "グラフの表示が崩れる場合は、パソコンなど、より大きな画面でご覧ください。"
+    ratingChanges:
+      title: "レーティング変動ランキング"
+      description: "月ごとのレーティング増加量で並べ替えたランキング"
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   resources :players, only: %i[index show]
   resources :players_comparisons, only: %i[index show create]
+  resources :rating_changes, only: %i[index]
   get '/all_players' => 'players#index_json'
   get '/' => 'players#root'
   get '/distribution' => 'home#distribution'

--- a/test/controllers/rating_changes_controller_test.rb
+++ b/test/controllers/rating_changes_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class RatingChangesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get rating_changes_path
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## Summary
- add a `rating_changes` controller and index view to rank monthly rating changes
- expose `/rating_changes` route and link in header
- add i18n strings for new page and nav link
- simple controller test for the new page

## Testing
- `bundle exec rails test` *(fails: ruby-2.5.9 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861ff92c4308331940d5a6bb7f84f88