### PR TITLE
Add ranking diff page

### DIFF
--- a/app/controllers/ranking_diffs_controller.rb
+++ b/app/controllers/ranking_diffs_controller.rb
@@ -1,0 +1,26 @@
+class RankingDiffsController < ApplicationController
+  def index
+    @ranking_diff_parameter = ranking_diff_params
+    month = @ranking_diff_parameter.month
+    last_month = month.last_month
+    current_records = Record.year_is(month.year).month_is(month.month).ordered
+    previous_records = Record.year_is(last_month.year).month_is(last_month.month)
+
+    @diffs = current_records.map do |record|
+      prev = previous_records.find { |p| p.player_id == record.player_id }
+      next unless prev
+      {
+        player: record.player,
+        current_rank: record.standard_rank,
+        last_rank: prev.standard_rank,
+        diff: prev.standard_rank - record.standard_rank
+      }
+    end.compact.sort_by { |h| -h[:diff] }
+  end
+
+  private
+
+  def ranking_diff_params
+    RankingDiffParameter.new(params.fetch(:ranking_diff_parameter, {}))
+  end
+end

--- a/app/models/ranking_diff_parameter.rb
+++ b/app/models/ranking_diff_parameter.rb
@@ -1,0 +1,22 @@
+class RankingDiffParameter
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+  include ActiveRecord::AttributeMethods::Write
+
+  attribute :month, :date, default: Record.latest_month
+
+  def initialize(params)
+    super(params.permit(:month))
+  end
+
+  def month=(value)
+    y = value.split('-')[0].to_i
+    m = value.split('-')[1].to_i
+    write_attribute(:month, Date.new(y, m, 5))
+  end
+
+  def selected_month
+    "#{month.year}-#{month.month}"
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,6 +13,12 @@
           <% end %>
         </li>
         <li class="nav-item">
+          <%= link_to ranking_diffs_path, {class: "nav-link"} do %>
+            <i class="fa-solid fa-arrows-up-down"></i>
+            <%= t('views.header.diffRanking') %>
+          <% end %>
+        </li>
+        <li class="nav-item">
           <%= link_to distribution_path, {class: "nav-link"} do %>
             <i class="fa-solid fa-chart-simple"></i>
             <%= t('views.header.distribution') %>

--- a/app/views/ranking_diffs/index.html.erb
+++ b/app/views/ranking_diffs/index.html.erb
@@ -1,0 +1,65 @@
+<% content_for :title do %>
+  <title><%= t('views.rankingDiffs.title') %></title>
+<% end %>
+<% content_for :description do %>
+  <meta name="description" content="<%= t('views.rankingDiffs.index.description') %>">
+<% end %>
+
+<div class="container" style="min-height: 100%;">
+  <div class='row mx-auto pl-1 pr-1 min-vh-100'>
+  <div class="d-flex flex-column mx-auto mw-100">
+  <div>
+    <%= render "layouts/header" %>
+    <h1>
+      <%= link_to ranking_diffs_path, {class: "nav-link text-body ps-0"} do %>
+        <i class="fa-solid fa-arrows-up-down"></i>
+        <%= t('views.rankingDiffs.title') %>
+      <% end %>
+    </h1>
+    <div>
+      <%= t('views.rankingDiffs.index.description') %>
+    </div>
+    <hr>
+  </div>
+
+  <div class="mb-3">
+    <%= form_with model: @ranking_diff_parameter, url: ranking_diffs_path, method: :get, local: true, skip_enforcing_utf8: true do |form| %>
+      <%= hidden_field_tag "locale", I18n.locale %>
+      <%= form.label :month, class: "align-middle" %>
+      <%= form.select :month, Record.month_array, {selected: @ranking_diff_parameter.selected_month}, {class: "align-middle"} %>
+      <%= form.submit "Update", name: nil, class: "btn btn-outline-primary ms-1 btn-sm" %>
+    <% end %>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Diff</th>
+        <th>Name</th>
+        <th>Last Rank</th>
+        <th>Current Rank</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @diffs.each do |d| %>
+        <tr>
+          <td>
+            <% if d[:diff] > 0 %>
+              <span class="text-success">↑<%= d[:diff] %></span>
+            <% elsif d[:diff] < 0 %>
+              <span class="text-danger">↓<%= d[:diff].abs %></span>
+            <% else %>
+              <span class="text-secondary">→0</span>
+            <% end %>
+          </td>
+          <td><%= link_to d[:player].name_en, d[:player] %></td>
+          <td><%= d[:last_rank] %></td>
+          <td><%= d[:current_rank] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       share: "Share"
     header:
       ranking: "Ranking"
+      diffRanking: "Rank Change"
       distribution: "Distribution"
       victoryDistance: "Victory Distance"
       comparePlayers: "Compare Players"
@@ -58,6 +59,10 @@ en:
       tooManyPlayers: "Maximum %{count} players can be displayed"
       ratingRange: "Rating range to display on the graph"
       graphInfo: "If the graph is distorted, please view it on a larger screen such as a computer."
+    rankingDiffs:
+      title: "Rank Change From Last Month"
+      index:
+        description: "Ranking of players sorted by how much their rank changed from the previous month."
   activerecord:
     errors:
       models:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       share: "シェア"
     header:
       ranking: "ランキング"
+      diffRanking: "順位変動"
       distribution: "分布"
       victoryDistance: "到達勝利距離"
       comparePlayers: "プレーヤー比較"
@@ -57,6 +58,10 @@ ja:
       tooManyPlayers: "最大%{count}人まで表示できます"
       ratingRange: "グラフに表示するレーティング範囲"
       graphInfo: "グラフの表示が崩れる場合は、パソコンなど、より大きな画面でご覧ください。"
+    rankingDiffs:
+      title: "先月からの順位変動"
+      index:
+        description: "先月からどれだけ順位が変動したかを表示します。"
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   resources :players, only: %i[index show]
   resources :players_comparisons, only: %i[index show create]
+  resources :ranking_diffs, only: [:index]
   get '/all_players' => 'players#index_json'
   get '/' => 'players#root'
   get '/distribution' => 'home#distribution'

--- a/test/controllers/ranking_diffs_controller_test.rb
+++ b/test/controllers/ranking_diffs_controller_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class RankingDiffsControllerTest < ActionDispatch::IntegrationTest
+  test 'should get index' do
+    get ranking_diffs_path
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## Summary
- add RankingDiffParameter model to choose month
- add RankingDiffsController#index that compares rank with the previous month
- show Rank Change link in header
- create ranking diff view
- add i18n strings for the new page
- include controller test

## Testing
- `bundle exec rake test` *(fails: ruby 2.5.9 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866724c9e448331be5a3fba1765a3fa